### PR TITLE
PDF output of tasklists revamped

### DIFF
--- a/application/controllers/TaskController.class.php
+++ b/application/controllers/TaskController.class.php
@@ -68,6 +68,10 @@
         $pdf = new FPDF();
         $pdf->AddPage();
         $pdf->SetTitle($task_list_name);
+        $pdf->SetCompression(true);
+        $pdf->SetCreator('ProjectPier');
+        $pdf->SetDisplayMode(fullpage, single);
+        $pdf->SetSubject(active_project()->getObjectName());
         $pdf->SetFont('Arial','B',16);
         $task_lists = active_project()->getOpenTaskLists();
         $pdf->Cell(0,10, lang('project') . ': ' . active_project()->getObjectName(), 'C');
@@ -85,16 +89,19 @@
           //  $this->Cell($w[$i],7,$header[$i],1,0,'C');
           //$this->Ln();
           $pdf->SetFont('Arial','I',14);
+          //$pdf->SetTextColor(255, 0, 0);
           foreach($tasks as $task) {
             $line++;
             if ($task->isCompleted()) {
               $task_status = lang('completed');
-              $task_completion_info = format_date($task->getCompletedOn());
+              $pdf->SetTextColor(100, 200, 100);
+              $task_completion_info = lang('completed task');
             } else {
               $task_status = lang('open');
-              $task_completion_info = '                ';
+              $pdf->SetTextColor(255, 0, 0);
+              $task_completion_info = lang('due date') . ' = ' . lang('not assigned');
               if ($task->getDueDate()) {
-                $task_completion_info = format_date($task->getDueDate());
+                $task_completion_info = lang('due date') . ' = ' . format_date($task->getDueDate());
               }
             }
             if ($task->getAssignedTo()) {
@@ -103,10 +110,23 @@
               $task_assignee = lang('not assigned');
             }
             $pdf->Cell($w[0],6,$line);
-            $pdf->Cell($w[1],6,$task_status . " / " . $task_completion_info . " / " . $task_assignee , "TLRB");
+            
+            $pdf->Cell($w[2],6,$task_status, "TLRB");
             $pdf->Ln();
             $pdf->Cell($w[0],6,'');
-            $pdf->MultiCell($w[2],6,$task->getText());
+            
+            $pdf->SetTextColor(0, 0, 0);
+            $pdf->Cell($w[2],6,$task_completion_info, "TLRB");
+            $pdf->Ln();
+            $pdf->Cell($w[0],6,'');
+            
+            $pdf->SetTextColor(0, 0, 0);
+            $pdf->Cell($w[2],6,$task_assignee, "TLRB");
+            $pdf->Ln();
+            $pdf->Cell($w[0],6,'');
+            
+            $pdf->SetTextColor(0, 0, 0);
+            $pdf->MultiCell($w[2],6,$task->getText(), "LRB");
             $pdf->Ln();
           }
         }

--- a/language/es_es/es_mx.php
+++ b/language/es_es/es_mx.php
@@ -1,8 +1,0 @@
-<?php
-  trace(__FILE__,':begin');
-  // Are we in Localization class? If not break!
-  if (!isset($this) || !($this instanceof Localization)) {
-    throw new InvalidInstanceError('$this', $this, 'Localization', "File '" . __FILE__ . "' can be included only from Localization class");
-  } // if
-  trace(__FILE__,':end');
-?>


### PR DESCRIPTION
Hey Reinier,

Ik heb wat dingen veranderd in de PDF output van de taaklijsten. (zie hieronder voor details)
Bekijk het op je gemak en laat me maar weten wat er nog beter kan, of dient te veranderen.
- use of colour to make open and closed status more obvious (still B&W printable)
- changed the layout to get more oversight
- PDF properties are now populated with relevant information for indexing
- PDF compression if ZLIB is present

EDIT: Ik heb ook nog een minor probleempje opgelost ivm es_es vertaling (zie commit voor meer info)

Groeten!
Engelbert
