### PR TITLE
EB: Removed "&" because php5.4 removed a function

### DIFF
--- a/public/patch/patch.php
+++ b/public/patch/patch.php
@@ -17,7 +17,7 @@ $sql = str_replace('{$tp}', DB_PREFIX, $sql);
 $sql = str_replace('<?php echo $table_prefix ?>', DB_PREFIX, $sql);
 $sql = str_replace('<?php echo $default_collation ?>', $co, $sql);
 $sql = str_replace('<?php echo $default_charset ?>', $cs, $sql);
-executeMultipleQueries($sql, &$total_queries, &$executed_queries, $link);
+executeMultipleQueries($sql, $total_queries, $executed_queries, $link);
 echo 'Summary' . "<br>\n";
 echo 'Total queries in SQL: ' . $total_queries . " <br>\n";
 echo 'Total executed queries: ' . $executed_queries  . " <br>\n";


### PR DESCRIPTION
"call-time pass-by-reference" is deprecated
see: http://www.projectpier.org/node/3375 (Schlchter11)

@phpfreak : Ik heb enkel lijn 20 veranderd, maar ik vrees dat mijn editor niet meer in utf8 en zonder bom staat.
toch even bekijken of we dit niet doorvoeren of als een extra bij in de brochure steken van de patch.
