### PR TITLE
Fixed potential issue with file revision not being moved to tmp directory

### DIFF
--- a/application/plugins/files/controllers/FilesController.class.php
+++ b/application/plugins/files/controllers/FilesController.class.php
@@ -562,6 +562,9 @@
           DB::beginWork();
           $uploaded_file = array_var($_FILES, 'file_file');
 
+          // move uploaded file to folder where I can read and write
+          move_uploaded_file($uploaded_file['tmp_name'], ROOT . '/tmp/' . $uploaded_file['name']);
+          $uploaded_file['tmp_name'] = ROOT . '/tmp/' . $uploaded_file['name'];
           //$file->setFilename(array_var($uploaded_file, 'name'));
           //$file->save();
           $revision = $file->handleUploadedFile($uploaded_file, true); // handle uploaded file


### PR DESCRIPTION
Adding revision was not moving the file to installation's ROOT/tmp
folder before saving, changed it to mimic the function that adds the
initial version of the file
