### PR TITLE
tiny changes to MysqlDBAdapter

### DIFF
--- a/environment/library/database/DB.class.php
+++ b/environment/library/database/DB.class.php
@@ -1,7 +1,7 @@
 <?php
 
   /**
-  * This function holds open database connections and provides interface to them. It is also used
+  * This class holds open database connections and provides interface to them. It is also used
   * for SQL logging
   *
   * @version 1.0

--- a/environment/library/database/adapters/MysqlDBAdapter.class.php
+++ b/environment/library/database/adapters/MysqlDBAdapter.class.php
@@ -262,7 +262,7 @@
     * @return string
     */
     function escapeField($field) {
-      return '`' . trim($field) . '`';
+      return '`' . str_replace('`', '``', trim($field)) . '`';
     } // escapeField
     
     /**
@@ -291,7 +291,7 @@
       } // if
       
       if (is_object($unescaped) && ($unescaped instanceof DateTimeValue)) {
-        return "'" . mysql_real_escape_string($unescaped->toMySQL()) . "'";
+		return "TIMESTAMP '" . mysql_real_escape_string($unescaped->toMySQL()) . "'";
       } // if
       
       return "'" . mysql_real_escape_string($unescaped, $this->link) . "'";


### PR DESCRIPTION
- MysqlDBAdapter->escapeField escapes "`"
- MysqlDBAdapter->escapeValue uses standard syntax for datetimes
