### PR TITLE
Fix error when displaying Milestone details

### DIFF
--- a/application/plugins/tickets/views/edit_ticket.php
+++ b/application/plugins/tickets/views/edit_ticket.php
@@ -98,7 +98,7 @@
       <td><?php echo select_milestone("ticket[milestone_id]", $ticket->getProject(), array_var($ticket_data, 'milestone_id'), array('id' => 'ticketFormMilestone')) ?></td>
 <?php } else { ?>
 <?php if($ticket->getMilestoneId()) { ?>
-      <td><?php echo lang($ticket->getMilestoneId()->getObjectName()); ?></td>
+      <td><?php echo clean($ticket->getMilestone()->getObjectName()); ?></td>
 <?php } else { ?>
       <td></td>
 <?php } // if?>


### PR DESCRIPTION
Code would result in error when canEdit=False, as getMilestoneID was being referenced instead of getMilestone.

Also, a lang() construct was used around the Milestone's name. As language strings can't be set by the user (and the Milestone name when elsewhere isn't treated like this) I replaced this with clean().
